### PR TITLE
Fixed wrong items quantity on last page.

### DIFF
--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -16,7 +16,7 @@ export async function paginate<T>(
   delete options.route;
 
   const [items, total] = await repository.findAndCount({
-    skip: page,
+    skip: page * limit,
     take: limit,
     ...(searchOptions as object),
   });


### PR DESCRIPTION
Hello, found another bug while used this. 
Here's the reproduction:
![Start](https://user-images.githubusercontent.com/24393965/56491951-0803f200-650c-11e9-9945-de3c4779f88b.png)
We have 61 items in our repository => 7 pages. 
When I go to last page my expectation is:
![Expectations](https://user-images.githubusercontent.com/24393965/56492035-4dc0ba80-650c-11e9-995a-1354cf58264f.png)
Actual behaviour is:
![Actual](https://user-images.githubusercontent.com/24393965/56492256-0c7cda80-650d-11e9-90ce-2f39f8c78b36.png)
So 10 items on 7/7 page with 61 total elements is kinda weird. This also leads to duplicates when fetching data from backend so I suppose this should not act like that.

Also when I "accidentally" go to non-existent page i expect to see this:
![Expectations x2](https://user-images.githubusercontent.com/24393965/56492432-a04ea680-650d-11e9-9c02-7091b2d5ccf5.png)
But actually is:
![Actualx2](https://user-images.githubusercontent.com/24393965/56492621-2ec32800-650e-11e9-8da6-d2524034aebf.png)
And
![Actualx3](https://user-images.githubusercontent.com/24393965/56492591-17843a80-650e-11e9-960c-0b4dcd4cc229.png)

I managed to fix that with that PR (this is way my "expectation" were created), but there is problem with test's. They won't pass and I bet the problem is manually created findAndCount func other there.




